### PR TITLE
Feature: export separate Zoom metrics file

### DIFF
--- a/Analyst/script/ImportandTransform.R
+++ b/Analyst/script/ImportandTransform.R
@@ -172,17 +172,15 @@ zoom_output_list <-
              utc_offset = use_utc_offset, # UPDATE AS APPROPRIATE
              return = "list")
 
-zoom_output <- zoom_output_list$full
-
 # The analyst can choose to export `zoom_output` or analyze directly
 # `zoom_output` is a WOWA format person-query data frame
 # You can run the following code chunk to:
 #   - standardise dates
 #   - create dummy after hours metric
 
-zoom_output %>%
-  mutate(Date = format(Date, "%m/%d/%Y")) %>%
-  as_tibble() %>%
+message("Exporting Person Query ...", stamp_time(start_t, unit = "secs"))
+
+zoom_output_list$full %>%
   write_csv(
     paste("../output/Zoom Transformed Person Query Export", # UPDATE AS APPROPRIATE
           tstamp(),
@@ -191,9 +189,10 @@ zoom_output %>%
   )
 
 # Save Zoom metrics separately
+
+message("Exporting Zoom Metrics ...", stamp_time(start_t, unit = "secs"))
+
 zoom_output_list$`zoom-metrics` %>%
-  mutate(Date = format(Date, "%m/%d/%Y")) %>%
-  as_tibble() %>%
   write_csv(
     paste("../output/Zoom Metrics Person Query Export", # UPDATE AS APPROPRIATE
           tstamp(),

--- a/Analyst/script/ImportandTransform.R
+++ b/Analyst/script/ImportandTransform.R
@@ -73,7 +73,7 @@ if(length(par_utc_offset) == 0){ # is of length 0
   message("If you are in the same timezone as Zoom Admin, no action needed")
   message("...")
   message("Continuing with execution..")
-  
+
   message(
     glue::glue("System timezone {tz_desc} detected.")
   )
@@ -82,7 +82,7 @@ if(length(par_utc_offset) == 0){ # is of length 0
     glue::glue("Using system UTC timezone offset of {use_utc_offset}")
   )
 
-  
+
   message("...")
 
 } else {
@@ -163,11 +163,16 @@ if(length(path_wowa) == 0){
 }
 
 # Convert to Person Query -------------------------------------------------
-zoom_output <- zoom_for_analyst %>%
+
+# A list object is returned
+zoom_output_list <-
+  zoom_for_analyst %>%
   zoom_to_pq(mq_key = unique(smq$Subject),
              wowa_file = wowa_df,
              utc_offset = use_utc_offset, # UPDATE AS APPROPRIATE
-             return = "full")
+             return = "list")
+
+zoom_output <- zoom_output_list$full
 
 # The analyst can choose to export `zoom_output` or analyze directly
 # `zoom_output` is a WOWA format person-query data frame
@@ -180,6 +185,17 @@ zoom_output %>%
   as_tibble() %>%
   write_csv(
     paste("../output/Zoom Transformed Person Query Export", # UPDATE AS APPROPRIATE
+          tstamp(),
+          ".csv"),
+    na = ""
+  )
+
+# Save Zoom metrics separately
+zoom_output_list$`zoom-metrics` %>%
+  mutate(Date = format(Date, "%m/%d/%Y")) %>%
+  as_tibble() %>%
+  write_csv(
+    paste("../output/Zoom Metrics Person Query Export", # UPDATE AS APPROPRIATE
           tstamp(),
           ".csv"),
     na = ""

--- a/Analyst/script/internal/zoom_to_pq.R
+++ b/Analyst/script/internal/zoom_to_pq.R
@@ -28,6 +28,7 @@
 #'   - `"full"`
 #'   - `"afterhours"`
 #'   - `"participants"`
+#'   - `"zoom-metrics"`
 
 zoom_to_pq <- function(data,
                        mq_key = "",
@@ -303,13 +304,24 @@ zoom_to_pq <- function(data,
                   by = c("Date" = "Date",
                          "HashID" = "User_Email_2"))
 
+    } else if(return == "zoom-metrics"){
+
+      wowa_file %>%
+        mutate(Date = as.Date(Date, "%m/%d/%Y")) %>%
+        left_join(
+          clean_pq %>%
+            select(
+              Date,
+              User_Email_2
+            ),
+          by = c("Date" = "Date",
+                 "HashID" = "User_Email_2"))
+
     } else {
 
       stop("Invalid return.")
 
     }
-
-
 
   }
 

--- a/Analyst/script/internal/zoom_to_pq.R
+++ b/Analyst/script/internal/zoom_to_pq.R
@@ -28,7 +28,7 @@
 #'   - `"full"`
 #'   - `"afterhours"`
 #'   - `"participants"`
-#'   - `"zoom-metrics"`
+#'   - `"list"`
 
 zoom_to_pq <- function(data,
                        mq_key = "",
@@ -304,9 +304,19 @@ zoom_to_pq <- function(data,
                   by = c("Date" = "Date",
                          "HashID" = "User_Email_2"))
 
-    } else if(return == "zoom-metrics"){
+    } else if(return == "list"){
 
-      wowa_file %>%
+      # Full metrics
+      out_full <-
+        wowa_file %>%
+        mutate(Date = as.Date(Date, "%m/%d/%Y")) %>%
+        left_join(clean_pq,
+                  by = c("Date" = "Date",
+                         "HashID" = "User_Email_2"))
+
+      # Zoom metrics
+      zm_full <-
+        wowa_file %>%
         mutate(Date = as.Date(Date, "%m/%d/%Y")) %>%
         left_join(
           clean_pq %>%
@@ -316,6 +326,12 @@ zoom_to_pq <- function(data,
             ),
           by = c("Date" = "Date",
                  "HashID" = "User_Email_2"))
+
+      # return list output
+      list(
+        "full" = out_full,
+        "zoom-metrics" = zm_full
+      )
 
     } else {
 

--- a/Analyst/script/internal/zoom_to_pq.R
+++ b/Analyst/script/internal/zoom_to_pq.R
@@ -133,7 +133,7 @@ zoom_to_pq <- function(data,
         utc_offset = utc_offset
       )
 
-  } else if(return %in% c("full", "minimal")){
+  } else if(return %in% c("full", "minimal", "list")){
 
     # Host metrics ------------------------------------------------------------
 
@@ -318,12 +318,12 @@ zoom_to_pq <- function(data,
       zm_full <-
         wowa_file %>%
         mutate(Date = as.Date(Date, "%m/%d/%Y")) %>%
+        select(
+          Date,
+          HashID
+        ) %>%
         left_join(
-          clean_pq %>%
-            select(
-              Date,
-              User_Email_2
-            ),
+          clean_pq,
           by = c("Date" = "Date",
                  "HashID" = "User_Email_2"))
 


### PR DESCRIPTION
# Summary
This branch implements a feature for analysts to export a separate Zoom metrics file. 

# Changes
The changes made in this PR are:
1. Updated `zoom_to_pq()` so that a list output can be returned. The two elements on the list enable both the combined WOWA query and the Zoom metrics output to be calculated at the same time.
1. `ImportandTransform.R` exports both outputs, taking the new list input from `zoom_to_pq()`. 

# Checks
- [ ] All scripts run with no errors. 
- [ ] The format of the Zoom metrics output matches what is required.
